### PR TITLE
Added variable substitution commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,66 @@ Following commands are available:
 - `Insert Timestamp` - Inserts current timestamp in milliseconds at the cursor position.
 - `Insert Formatted DateTime` (<kbd>⇧</kbd>+<kbd>⌘</kbd>+<kbd>⌥</kbd>+<kbd>I</kbd> on OS X, <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>I</kbd> on Windows and Linux) - Prompt user for format and insert formatted date and/or time at the cursor position.
 
+Each command is also available as a variable expansion, which is particularly useful for [task input variables](https://code.visualstudio.com/docs/editor/variables-reference#_input-variables).
+
+- `insertDateString.getDateTime` - Returns current date and/or time according to configured format (`format`).
+- `insertDateString.getDate` - Returns current date according to configured format (`formatDate`).
+- `insertDateString.getTime` - Returns current time according to configured format (`formatTime`).
+- `insertDateString.getTimestamp` - Returns current timestamp in milliseconds.
+- `insertDateString.getOwnFormatDateTime` - Returns formatted date and/or time according to provided format.
+
+``` json
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "print default datetime",
+			"type": "shell",
+			"command": "echo",
+			"args": ["${input:dateTime}"]
+		},
+		{
+			"label": "print custom datetime",
+			"type": "shell",
+			"command": "echo",
+			"args": ["${input:formatDateTime}"]
+		},
+		{
+			"label": "print prompted datetime",
+			"type": "shell",
+			"command": "echo",
+			"args": ["${input:promptedDateTime}"]
+		}
+	],
+	"inputs": [
+		{
+			"id": "dateTime",
+			"type": "command",
+			"command": "insertDateString.getDateTime"
+		},
+		{
+			"id": "formatDateTime",
+			"type": "command",
+			"command": "insertDateString.getOwnFormatDateTime",
+			"args": "hh:mm:ss YYYY-MM-DD"
+		},
+		{
+			"id": "promptedDateTime",
+			"type": "command",
+			"command": "insertDateString.getOwnFormatDateTime"
+			// notice lack of args here
+		}
+	]
+}
+```
+
 ## Available settings
 
 - Date and time format string (_this affects `Insert DateTime` output_):
 - Date format string (_this affects `Insert Date` output_):
 - Time format string (_this affects `Insert Time` output_):
 
-```
+``` json
 // Date format to be used.
 "insertDateString.format": "YYYY-MM-DD hh:mm:ss",
 "insertDateString.formatDate": "YYYY-MM-DD",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,12 @@
     "onCommand:insertDateString.insertDate",
     "onCommand:insertDateString.insertTime",
     "onCommand:insertDateString.insertTimestamp",
-    "onCommand:insertDateString.insertOwnFormatDateTime"
+    "onCommand:insertDateString.insertOwnFormatDateTime",
+    "onCommand:insertDateString.getDateTime",
+    "onCommand:insertDateString.getDate",
+    "onCommand:insertDateString.getTime",
+    "onCommand:insertDateString.getTimestamp",
+    "onCommand:insertDateString.getOwnFormatDateTime"
   ],
   "categories": [
     "Other",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,6 +32,7 @@ function replaceEditorSelection(text: string) {
 }
 
 export function activate(context: ExtensionContext): void {
+  // User-facing commands (exposed in contributions)
   context.subscriptions.push(
     commands.registerCommand("insertDateString.insertDateTime", () =>
       replaceEditorSelection(getFormattedDateString())
@@ -61,15 +62,59 @@ export function activate(context: ExtensionContext): void {
   );
 
   context.subscriptions.push(
-    commands.registerCommand("insertDateString.insertOwnFormatDateTime", () => {
-      window
-        .showInputBox({
+    commands.registerCommand("insertDateString.insertOwnFormatDateTime", async () => {
+      const format = await window.showInputBox({
+        value: getConfiguredFormat(),
+        prompt: INPUT_PROMPT,
+      });
+
+      if (format != null) {
+        replaceEditorSelection(getFormattedDateString(format));
+      }
+    })
+  );
+
+  // Can be used in task inputs and other variable substitutions
+  context.subscriptions.push(
+    commands.registerCommand("insertDateString.getDateTime", () => {
+      return getFormattedDateString();
+    })
+  );
+
+  context.subscriptions.push(
+    commands.registerCommand("insertDateString.getDate", () => {
+      return getFormattedDateString(getConfiguredFormat("formatDate"));
+    })
+  );
+
+  context.subscriptions.push(
+    commands.registerCommand("insertDateString.getTime", () => {
+      return getFormattedDateString(getConfiguredFormat("formatTime"));
+    })
+  );
+
+  context.subscriptions.push(
+    commands.registerCommand("insertDateString.getTimestamp", () => {
+      return new Date().getTime().toString();
+    })
+  );
+
+  context.subscriptions.push(
+    commands.registerCommand("insertDateString.getOwnFormatDateTime", async format => {
+      if (format != null) {
+        return getFormattedDateString(format);
+      } else {
+        const format = await window.showInputBox({
           value: getConfiguredFormat(),
           prompt: INPUT_PROMPT,
-        })
-        .then((format) => {
-          replaceEditorSelection(getFormattedDateString(format));
         });
+
+        if (format != null) {
+          return getFormattedDateString(format);
+        } else {
+          return undefined;
+        }
+      }
     })
   );
 }


### PR DESCRIPTION
I added a few commands that mirror the existing ones but return the date strings directly instead of inserting them into the currently focused editor. This is mainly useful for variable expansions in task or launch files. I personally use this to add a timestamp to the name of build archives for one of my games! I documented their usage in the README.

I also fixed a bug where canceling the date format prompt would still insert the date string.