### PR TITLE
Adding in support for generating an ISO8601 datetime string that includes milliseconds

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,6 +14,9 @@ function getConfiguredFormat(format = "format"): string {
 
 function getFormattedDateString(userFormat = getConfiguredFormat()): string {
   const now = new Date();
+  if (userFormat === "isoSS") {
+    return now.toISOString();
+  }
   return now.format(userFormat);
 }
 


### PR DESCRIPTION
Probably not the best way to implement this, but this change is backwards compatible and unblocked me as I needed a genuine ISO8601 datetime string that included milliseconds - e.g. calls `Date.toISOString()` - as currently the 'iso' format leaves that off which makes it unsuitable for certain use cases.

For backwards compatibility this commit adds this in if a new 'isoSS' format is specified.

Submitting this PR in case it helps anyone else.