### PR TITLE
Add timezone support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,32 @@ Following commands are available:
 - Date and time format string (_this affects `Insert DateTime` output_):
 - Date format string (_this affects `Insert Date` output_):
 - Time format string (_this affects `Insert Time` output_):
+- Timezone (_applies to all format-based commands; leave empty for local system time_):
 
 ```
 // Date format to be used.
 "insertDateString.format": "YYYY-MM-DD HH:mm:ss",
 "insertDateString.formatDate": "YYYY-MM-DD",
 "insertDateString.formatTime": "HH:mm:ss",
+// Timezone (IANA name, e.g. "America/New_York"). Default: "" (local time).
+"insertDateString.timezone": "",
 ```
+
+## Timezone
+
+Set `insertDateString.timezone` to an [IANA timezone name](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) to produce timestamps in a consistent timezone regardless of the local system clock. This is useful for distributed teams that need to agree on a shared reference timezone.
+
+```json
+"insertDateString.timezone": "America/New_York"
+```
+
+**Supported values:** Any IANA timezone name (e.g. `UTC`, `America/New_York`, `Europe/Warsaw`, `Asia/Tokyo`). Leave empty to use local system time.
+
+**Affected commands:** `Insert DateTime`, `Insert Date`, `Insert Time`, `Insert Formatted DateTime`.
+
+**Unaffected commands:** `Insert Timestamp` always produces a Unix timestamp in milliseconds (UTC by definition). The `iso` format token always outputs UTC regardless of this setting.
+
+If the configured value is not a valid IANA timezone, a warning is shown and local system time is used as a fallback.
 
 ## Syntax
 

--- a/package.json
+++ b/package.json
@@ -105,6 +105,11 @@
           "type": "string",
           "default": "HH:mm:ss",
           "description": "Time format to be used."
+        },
+        "insertDateString.timezone": {
+          "type": "string",
+          "default": "",
+          "description": "IANA timezone name (e.g. 'America/New_York', 'Europe/Warsaw', 'UTC'). Leave empty to use local system time."
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,8 +3,12 @@
 import { commands, workspace, window, ExtensionContext } from "vscode";
 import dayjs from "dayjs";
 import isoWeekPlugin from "dayjs/plugin/isoWeek";
+import utcPlugin from "dayjs/plugin/utc";
+import timezonePlugin from "dayjs/plugin/timezone";
 
 dayjs.extend(isoWeekPlugin);
+dayjs.extend(utcPlugin);
+dayjs.extend(timezonePlugin);
 
 const INPUT_PROMPT = "Date and Time format";
 const DEFAULT_FORMAT = "YYYY-MM-DD HH:mm:ss";
@@ -16,10 +20,51 @@ function getConfiguredFormat(format = "format"): string {
   return insertDateStringConfiguration.get(format, DEFAULT_FORMAT);
 }
 
-function getFormattedDateString(userFormat = getConfiguredFormat()): string {
-  const now = dayjs();
+function isValidTimezone(tz: string): boolean {
+  try {
+    new Intl.DateTimeFormat(undefined, { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
 
-  // Special-case: "iso" outputs a simplified ISO 8601 string (UTC, no milliseconds)
+function getConfiguredTimezone(): string | undefined {
+  const tz = workspace
+    .getConfiguration("insertDateString")
+    .get<string>("timezone", "");
+  return tz || undefined;
+}
+
+function getFormattedDateString(userFormat = getConfiguredFormat()): string {
+  const timezone = getConfiguredTimezone();
+  let now: dayjs.Dayjs;
+
+  if (timezone) {
+    if (isValidTimezone(timezone)) {
+      now = dayjs().tz(timezone);
+    } else {
+      void window
+        .showWarningMessage(
+          `Insert Date String: "${timezone}" is not a valid IANA timezone. Using local time.`,
+          "Open Settings",
+        )
+        .then((selection) => {
+          if (selection === "Open Settings") {
+            void commands.executeCommand(
+              "workbench.action.openSettings",
+              "insertDateString.timezone",
+            );
+          }
+        });
+      now = dayjs();
+    }
+  } else {
+    now = dayjs();
+  }
+
+  // Special-case: "iso" outputs a simplified ISO 8601 string.
+  // toISOString() always returns UTC regardless of any configured timezone — by design.
   if (userFormat === "iso") {
     return now.toISOString().replace(/\.\d{3}Z$/, "Z");
   }


### PR DESCRIPTION
closes #29 #28 

Adds a new `insertDateString.timezone` setting that accepts an IANA timezone name (e.g. America/New_York). When set, all format-based commands produce timestamps in the configured timezone instead of local system time. Falls back to local time with a warning if the value is invalid. Insert Timestamp is unaffected (Unix ms is UTC by definition).