### PR TITLE
Clear selection after inserting date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-insertdatestring",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-insertdatestring",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "license": "MIT",
       "dependencies": {
         "dayjs": "^1.11.20"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-insertdatestring",
   "displayName": "Insert Date String",
   "description": "Insert the current date and time according to configured format.",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "publisher": "jsynowiec",
   "homepage": "https://github.com/jsynowiec/vscode-insertdatestring#readme",
   "bugs": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,12 @@
 // ABOUTME: VS Code extension entry point — registers date/time insertion commands.
 // ABOUTME: Inserts formatted date strings into the active editor using dayjs.
-import { commands, workspace, window, ExtensionContext } from "vscode";
+import {
+  commands,
+  workspace,
+  window,
+  ExtensionContext,
+  SnippetString,
+} from "vscode";
 import dayjs from "dayjs";
 import isoWeekPlugin from "dayjs/plugin/isoWeek";
 import advancedFormatPlugin from "dayjs/plugin/advancedFormat";
@@ -96,13 +102,11 @@ function getFormattedDateString(userFormat = getConfiguredFormat()): string {
 }
 
 async function replaceEditorSelection(text: string): Promise<void> {
+  const snippet = new SnippetString(text + "$0");
   const editor = window.activeTextEditor;
   if (!editor) return;
-  const success = await editor.edit((editBuilder) => {
-    editor.selections.forEach((selection) => {
-      editBuilder.replace(selection, text);
-    });
-  });
+
+  const success = await editor.insertSnippet(snippet);
   if (!success) {
     void window.showWarningMessage(
       "Could not insert date string into a read-only document.",


### PR DESCRIPTION
`insertSnippet()` handles multi-cursor insertions, removes the selection, and positions the cursor at the end of inserted text. It'll also allow supporting the other part of #35 after I consider escaping literal `$` in the format string.